### PR TITLE
[FIN]: Update `nodash` version to `v0.41.1`

### DIFF
--- a/circuits/circuit-for-zkemail-1024-bit-dkim/Nargo.toml
+++ b/circuits/circuit-for-zkemail-1024-bit-dkim/Nargo.toml
@@ -6,7 +6,9 @@ compiler_version = ">=1.0.0"
 version = "0.0.1"
 
 [dependencies]
-jwt = { tag = "v0.4.4", git = "https://github.com/saleel/noir-jwt" }
-#jwt = { tag = "v0.5.0", git = "https://github.com/zkemail/noir-jwt" }
+# zkJWT
+jwt = { tag = "v0.5.0", git = "https://github.com/zkemail/noir-jwt" }
 
-zkemail = { tag = "v0.4.3", git = "https://github.com/zkemail/zkemail.nr", directory = "lib" }
+# zkEmail
+zkemail = { git = "https://github.com/masaun/zkemail.nr", tag = "feat/update-packages_nodash-v0.41.1", directory = "lib" }   # The original zkemail.nr package (version: "zkemail.nr_v.1.0.0-beta.5") with updated dependency (nodash v0.41.1)
+sha256 = { tag = "v0.1.2", git = "https://github.com/noir-lang/sha256" } # This module is needed for the zkemail.nr package to work properly along with the nodash v0.41.1

--- a/circuits/circuit-for-zkemail-1024-bit-dkim/src/tests/mod.nr
+++ b/circuits/circuit-for-zkemail-1024-bit-dkim/src/tests/mod.nr
@@ -24,12 +24,13 @@ mod test_zkemail_integration_success {
 
     use zkemail::{
         headers::{body_hash::get_body_hash, email_address::get_email_address},
-        MAX_EMAIL_ADDRESS_LENGTH, partial_hash::partial_sha256_var_end,
+        MAX_EMAIL_ADDRESS_LENGTH, 
+        partial_hash::partial_sha256_var_end,
         dkim::RSAPubkey, Sequence,
         KEY_LIMBS_1024
     };
 
-    use std::hash::sha256_var;
+    //use std::hash::sha256_var;
 
     #[test]
     fn test_verify_position_and_salary_and_verify_email_1024_bit_dkim() {
@@ -104,11 +105,13 @@ mod test_zkemail_modules_success {
 
     use zkemail::{
         headers::{body_hash::get_body_hash, email_address::get_email_address},
-        MAX_EMAIL_ADDRESS_LENGTH, partial_hash::partial_sha256_var_end,
+        MAX_EMAIL_ADDRESS_LENGTH, 
+        partial_hash::partial_sha256_var_end,
         dkim::RSAPubkey, KEY_LIMBS_2048, Sequence
     };
 
-    use std::hash::sha256_var;
+    use dep::sha256;
+    //use std::hash::sha256_var;
 
     #[test]
     fn test_dkim_signature() {
@@ -125,7 +128,8 @@ mod test_zkemail_modules_success {
         );
         // compute the body hash
         let computed_body_hash: [u8; 32] =
-            sha256_var(EmailLarge::BODY.storage(), EmailLarge::BODY.len() as u64);
+            sha256::sha256_var(EmailLarge::BODY.storage(), EmailLarge::BODY.len() as u64);
+            //sha256_var(EmailLarge::BODY.storage(), EmailLarge::BODY.len() as u64);
         // compare the body hashes
         assert(
             signed_body_hash == computed_body_hash,

--- a/circuits/circuit-for-zkemail-1024-bit-dkim/src/utils/email_dkim_verifier.nr
+++ b/circuits/circuit-for-zkemail-1024-bit-dkim/src/utils/email_dkim_verifier.nr
@@ -1,4 +1,6 @@
-use std::{collections::bounded_vec::BoundedVec, hash::{pedersen_hash, sha256_var}};
+use std::{collections::bounded_vec::BoundedVec, hash::{pedersen_hash}};
+//use std::{collections::bounded_vec::BoundedVec, hash::{pedersen_hash, sha256_var}};
+
 use zkemail::{
     dkim::RSAPubkey, 
     headers::body_hash::get_body_hash, 
@@ -37,7 +39,8 @@ fn verify_email_1024_bit_dkim(
     //signature: [Field; KEY_LIMBS_2048],
     body_hash_index: u32,
     dkim_header_sequence: Sequence,
-) -> pub [Field; 2] {
+) -> [Field; 2] {        // @dev - Since Noir (Nargo) version v1.0.0, the `pub` keyword can not be used for the return value of the internal function.   
+//) -> pub [Field; 2] {
     // check the body and header lengths are within bounds
     assert(header.len() <= MAX_EMAIL_HEADER_LENGTH);
     assert(body.len() <= MAX_EMAIL_BODY_LENGTH);
@@ -52,7 +55,8 @@ fn verify_email_1024_bit_dkim(
 
     // ~ 113,962 constraints
     // hash the asserted body
-    let computed_body_hash: [u8; 32] = sha256_var(body.storage, body.len() as u64);
+    let computed_body_hash: [u8; 32] = sha256::sha256_var(body.storage, body.len() as u64);
+    //let computed_body_hash: [u8; 32] = sha256_var(body.storage, body.len() as u64);
 
     // compare the body hashes
     assert(

--- a/circuits/circuit-for-zkemail-2048-bit-dkim/Nargo.toml
+++ b/circuits/circuit-for-zkemail-2048-bit-dkim/Nargo.toml
@@ -3,10 +3,12 @@ name = "openbands"
 type = "bin"
 authors = ["Stratos", "masaun"]
 compiler_version = ">=1.0.0"
-version = "0.1.0"
+version = "0.0.1"
 
 [dependencies]
-jwt = { tag = "v0.4.4", git = "https://github.com/saleel/noir-jwt" }
-#jwt = { tag = "v0.5.0", git = "https://github.com/zkemail/noir-jwt" }
+# zkJWT
+jwt = { tag = "v0.5.0", git = "https://github.com/zkemail/noir-jwt" }
 
-zkemail = { tag = "v0.4.3", git = "https://github.com/zkemail/zkemail.nr", directory = "lib" }
+# zkEmail
+zkemail = { git = "https://github.com/masaun/zkemail.nr", tag = "feat/update-packages_nodash-v0.41.1", directory = "lib" }   # The original zkemail.nr package (version: "zkemail.nr_v.1.0.0-beta.5") with updated dependency (nodash v0.41.1)
+sha256 = { tag = "v0.1.2", git = "https://github.com/noir-lang/sha256" } # This module is needed for the zkemail.nr package to work properly along with the nodash v0.41.1

--- a/circuits/circuit-for-zkemail-2048-bit-dkim/src/tests/mod.nr
+++ b/circuits/circuit-for-zkemail-2048-bit-dkim/src/tests/mod.nr
@@ -23,12 +23,13 @@ mod test_zkemail_integration_success {
 
     use zkemail::{
         headers::{body_hash::get_body_hash, email_address::get_email_address},
-        MAX_EMAIL_ADDRESS_LENGTH, partial_hash::partial_sha256_var_end,
+        MAX_EMAIL_ADDRESS_LENGTH, 
+        partial_hash::partial_sha256_var_end,
         dkim::RSAPubkey, Sequence,
         KEY_LIMBS_2048
     };
 
-    use std::hash::sha256_var;
+    //use std::hash::sha256_var;
 
     #[test]
     fn test_verify_position_and_salary_and_verify_email_2048_bit_dkim() {
@@ -103,11 +104,13 @@ mod test_zkemail_modules_success {
 
     use zkemail::{
         headers::{body_hash::get_body_hash, email_address::get_email_address},
-        MAX_EMAIL_ADDRESS_LENGTH, partial_hash::partial_sha256_var_end,
+        MAX_EMAIL_ADDRESS_LENGTH, 
+        partial_hash::partial_sha256_var_end,
         dkim::RSAPubkey, KEY_LIMBS_2048, Sequence
     };
 
-    use std::hash::sha256_var;
+    use dep::sha256;
+    //use std::hash::sha256_var;
 
     #[test]
     fn test_dkim_signature() {
@@ -124,7 +127,9 @@ mod test_zkemail_modules_success {
         );
         // compute the body hash
         let computed_body_hash: [u8; 32] =
-            sha256_var(EmailLarge::BODY.storage(), EmailLarge::BODY.len() as u64);
+            sha256::sha256_var(EmailLarge::BODY.storage(), EmailLarge::BODY.len() as u64);
+            //sha256_var(EmailLarge::BODY.storage(), EmailLarge::BODY.len() as u64);
+
         // compare the body hashes
         assert(
             signed_body_hash == computed_body_hash,

--- a/circuits/circuit-for-zkemail-2048-bit-dkim/src/utils/email_dkim_verifier.nr
+++ b/circuits/circuit-for-zkemail-2048-bit-dkim/src/utils/email_dkim_verifier.nr
@@ -1,4 +1,6 @@
-use std::{collections::bounded_vec::BoundedVec, hash::{pedersen_hash, sha256_var}};
+use std::{collections::bounded_vec::BoundedVec, hash::{pedersen_hash}};
+//use std::{collections::bounded_vec::BoundedVec, hash::{pedersen_hash, sha256_var}};
+
 use zkemail::{
     dkim::RSAPubkey, 
     headers::body_hash::get_body_hash, 
@@ -31,7 +33,8 @@ fn verify_email_2048_bit_dkim_without_body_hash_check(
     pubkey: RSAPubkey<KEY_LIMBS_2048>,
     signature: [Field; KEY_LIMBS_2048],
     dkim_header_sequence: Sequence,
-) -> pub [Field; 2] {
+) -> [Field; 2] {        // @dev - Since Noir (Nargo) version v1.0.0, the `pub` keyword can not be used for the return value of the internal function.   
+//) -> pub [Field; 2] {
     // check the body and header lengths are within bounds
     assert(header.len() <= MAX_EMAIL_HEADER_LENGTH);
 


### PR DESCRIPTION
Update the **nodash** version to `v0.41.1` in order to use the **zkemail.nr** along with the **noir-jwt** `v0.5.0` (under the nargo version = `1.0.0-beta.4`).

(NOTE: At this point, using `v0.41.1` of nodash is aligned to the **noir-jwt** `v0.5.0`)

Using the **nodash** `>= v0.41.0` is also important for the following modules:
- **openbanking.nr**
- **noir-web-prover-circuits**

etc...